### PR TITLE
add scripts to fix (spatial) restart problem

### DIFF
--- a/postprocessing_h5py/check_h5file.py
+++ b/postprocessing_h5py/check_h5file.py
@@ -62,10 +62,13 @@ def main(folder, correct, wrong):
     map_index = []
     
     # create a list of the index for swapping the wrong node numbering with the correct node numbering
-    for values in index_dict.values():
-        for i in range(len(wrongNumberNodes)):
-            if (values == wrongNumberNodes[i]).all():
-                map_index.append(i)
+    
+    for i, values in enumerate(index_dict.values()):
+        if i % 1000 == 0:
+            print(f"Creating map_index: Going through {i} nodes out of {len(index_dict)} nodes")
+        for j in range(len(wrongNumberNodes)):
+            if (values == wrongNumberNodes[j]).all():
+                map_index.append(j)
 
     # fix the node numbering in the wrong visualization file and overwrite the wrong h5 file
     fixed_nodes = wrongNumberNodes[map_index]
@@ -76,6 +79,8 @@ def main(folder, correct, wrong):
 
     # based on the index, we can now fix the node numbering in the h5 file
     for i in range(len(wrongNumberViz["VisualisationVector"].keys())):
+        if i % 1000 == 0:
+            print(f"Fixing vectors: Going through {i} time steps out of {len(wrongNumberViz['VisualisationVector'].keys())} steps")
         wrongNumberViz["VisualisationVector"][str(i)][...] = np.array(wrongNumberViz["VisualisationVector"][str(i)])[map_index]
 
     # close the files

--- a/postprocessing_h5py/check_h5file.py
+++ b/postprocessing_h5py/check_h5file.py
@@ -1,0 +1,90 @@
+import os
+import h5py
+import numpy as np
+from argparse import ArgumentParser
+
+"""
+Author: Kei Yamamoto <keiya@simula.no>
+Last updated: 2023/05/19
+When restarting a simulation in turtleFSI, the visualization files are not always correct due to different mesh partitioning.
+This scripts fixes the visualization files by checking mesh in h5 files and swapping the node numbering, tpoology, and vector values.
+After running this script, you can use the combine_xdmf.py script to merge the visualization files.
+"""
+
+def parse_args():
+    parser = ArgumentParser()
+    parser.add_argument("--folder", help="Path to the folder containing the visualization files")
+    parser.add_argument("--correct", help="Path to the correct visualization file")
+    parser.add_argument("--wrong", help="Path to the wrong visualization file")
+    args = parser.parse_args()
+    return args
+
+def main(folder, correct, wrong):
+    """
+    Args:
+        folder (str): Path to the folder containing the visualization files
+        correct (str): Path to the correct visualization file, usually velocity/displacement/pressure.h5 
+        wrong (str): Path to the wrong visualization file, usually velocity/displacement/pressure_run_{i}.h5, i = 1, 2, 3, ...
+
+    Returns:
+        None
+    """
+    # Here we find the path to the visualization files 
+    wrongNumberVizPath = os.path.join(folder, wrong)
+    correctNumberVizPath = os.path.join(folder, correct)
+
+    # Open the files using h5py, r+ means read and write
+    wrongNumberViz = h5py.File(wrongNumberVizPath, 'r+')
+    correctNumberViz = h5py.File(correctNumberVizPath, 'r+')
+
+    # Get the mesh coordinates from the mesh
+    wrongNumberNodes = wrongNumberViz['Mesh/0/mesh/geometry'][:]
+    correctNumberNodes = correctNumberViz['Mesh/0/mesh/geometry'][:]
+
+    # Here, we simply copy toplogy from the correct file to the wrong file if they are not the same
+    if (correctNumberViz['Mesh/0/mesh/topology'][:] != wrongNumberViz['Mesh/0/mesh/topology'][:]).all():
+        print('Topology is not the same')
+        wrongNumberViz['Mesh/0/mesh/topology'][...] = correctNumberViz['Mesh/0/mesh/topology'][:]
+        print('Topology is now fixed')
+    else:
+        print('Topology is the same')
+
+    # Check if the node numbering is correct
+    if (correctNumberNodes == wrongNumberNodes).all():
+        print('Node numbering is correct')
+        print('...exiting')
+        exit()
+    else:
+        print('Node numbering is incorrect')
+   
+    # Create a dictionary with the index and coordinates of the correct node numbering
+    index_dict =  {index: value for index, value in enumerate(correctNumberNodes)}
+    map_index = []
+    
+    # create a list of the index for swapping the wrong node numbering with the correct node numbering
+    for values in index_dict.values():
+        for i in range(len(wrongNumberNodes)):
+            if (values == wrongNumberNodes[i]).all():
+                map_index.append(i)
+
+    # fix the node numbering in the wrong visualization file and overwrite the wrong h5 file
+    fixed_nodes = wrongNumberNodes[map_index]
+    wrongNumberViz['Mesh/0/mesh/geometry'][...] = fixed_nodes
+
+    assert (correctNumberNodes == wrongNumberViz['Mesh/0/mesh/geometry'][:]).all()
+    print('Node numbering is now fixed')
+
+    # based on the index, we can now fix the node numbering in the h5 file
+    for i in range(len(wrongNumberViz["VisualisationVector"].keys())):
+        wrongNumberViz["VisualisationVector"][str(i)][...] = np.array(wrongNumberViz["VisualisationVector"][str(i)])[map_index]
+
+    # close the files
+    wrongNumberViz.close()
+    correctNumberViz.close()
+
+if __name__ == '__main__':
+    args = parse_args()
+    folder = args.folder
+    correct = args.correct
+    wrong = args.wrong
+    main(folder, correct, wrong)

--- a/postprocessing_h5py/combine_xdmf.py
+++ b/postprocessing_h5py/combine_xdmf.py
@@ -1,0 +1,72 @@
+from xml.etree import ElementTree as ET
+from pathlib import Path
+from argparse import ArgumentParser
+
+"""
+Author: Kei Yamamoto <keiya@simula.np>
+Last updated: 2023/05/19
+This script is used to merge xdmf files from a restart problem and is part of turtleFSI.
+However, in some cases, the visualization files are not correct due to different mesh partitioning and thus should not be merged before fixing them.
+The script is used in conjunction with the check_h5file.py script. Make sure that the node numbering of h5 files is correct before running this script.
+"""
+
+def parse_args():
+    parser = ArgumentParser()
+    parser.add_argument("--folder", help="Path to the folder containing the visualization files")
+    args = parser.parse_args()
+    return args
+
+def merge_visualization_files(visualization_folder, **namesapce):
+    # Gather files
+    xdmf_files = list(visualization_folder.glob("*.xdmf"))
+    xdmf_displacement = [f for f in xdmf_files if "displacement" in f.__str__()]
+    xdmf_velocity = [f for f in xdmf_files if "velocity" in f.__str__()]
+    xdmf_pressure = [f for f in xdmf_files if "pressure" in f.__str__()]
+
+    # Merge files
+    for files in [xdmf_displacement, xdmf_velocity, xdmf_pressure]:
+        if len(files) > 1:
+            merge_xml_files(files)
+
+def merge_xml_files(files):
+    # Get first timestep and trees
+    first_timesteps = []
+    trees = []
+    for f in files:
+        trees.append(ET.parse(f))
+        root = trees[-1].getroot()
+        first_timesteps.append(float(root[0][0][0][2].attrib["Value"]))
+
+    # Index valued sort (bypass numpy dependency)
+    first_timestep_sorted = sorted(first_timesteps)
+    indexes = [first_timesteps.index(i) for i in first_timestep_sorted]
+
+    # Get last timestep of first tree
+    base_tree = trees[indexes[0]]
+    last_node = base_tree.getroot()[0][0][-1]
+    ind = 1 if len(list(last_node)) == 3 else 2
+    last_timestep = float(last_node[ind].attrib["Value"])
+
+    # Append
+    for index in indexes[1:]:
+        tree = trees[index]
+        for node in list(tree.getroot()[0][0]):
+            ind = 1 if len(list(node)) == 3 else 2
+            if last_timestep < float(node[ind].attrib["Value"]):
+                base_tree.getroot()[0][0].append(node)
+                last_timestep = float(node[ind].attrib["Value"])
+
+    # Seperate xdmf files
+    new_file = [f for f in files if "_" not in f.name.__str__()]
+    old_files = [f for f in files if "_" in f.name.__str__()]
+
+    # Write new xdmf file
+    base_tree.write(new_file[0], xml_declaration=True)
+
+    # Delete xdmf file
+    [f.unlink() for f in old_files]
+
+if __name__ == "__main__":
+    args = parse_args()
+    folder = Path(args.folder)
+    merge_visualization_files(folder)


### PR DESCRIPTION
Hi @dbruneau-mie 

This PR adds two scripts that can be used to fix h5/xdmf files with inconsistent mesh information. 
When restarting turtleFSI, h5 files can contain mesh/vector information with different ordering due to different mesh partitioning and `check_h5file.py` can be used to correct the mesh/vector ordering based on one of the h5 files. 
After fixing, one can use `combine_xdmf.py’ to safely merge xdmf files. This also means that it is better not to merge visualization files at the end of the simulation, but we can come back to this in the turtle meeting.

Please let me know if you have any questions!

Best,
Kei 

